### PR TITLE
Fix: weights should be float64

### DIFF
--- a/client/nutrition.go
+++ b/client/nutrition.go
@@ -1,0 +1,27 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/galeone/fitbit/v2/types"
+)
+
+// /1/user/[user-id]/foods/log/date/[date].json
+func (c *Client) FoodLogList(date time.Time) (ret *types.FoodLogList, err error) {
+	path := fmt.Sprintf("/foods/log/date/%s.json", date.Format(types.DateLayout))
+
+	var res *http.Response
+	if res, err = c.req.Get(UserV1(path)); err != nil {
+		return
+	}
+
+	err = json.NewDecoder(res.Body).Decode(&ret)
+	return
+}

--- a/types/nutrition.go
+++ b/types/nutrition.go
@@ -1,0 +1,50 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package types
+
+type FoodLog struct {
+	IsFavorite  bool        `json:"isFavorite"`
+	LogDate     FitbitDate  `json:"logDate"`
+	LogId       int64       `json:"logId"`
+	LoggedFood  LoggedFood  `json:"loggedFood"`
+	Nutritional Nutritional `json:"nutritionalValues"`
+}
+
+type FoodLogList struct {
+	Foods []FoodLog `json:"foods"`
+	Goals struct {
+		Calories int64 `json:"calories"`
+	} `json:"goals"`
+	Summary Nutritional `json:"summary"`
+}
+
+type LoggedFood struct {
+	AccessLevel string         `json:"accessLevel"`
+	Amount      float64        `json:"amount"`
+	Brand       string         `json:"brand"`
+	Calories    int64          `json:"calories"`
+	FoodID      int64          `json:"foodId"`
+	Locale      string         `json:"locale"`
+	MealType    int64          `json:"mealTypeId"`
+	Name        string         `json:"name"`
+	Unit        LoggedFoodUnit `json:"unit"`
+	Units       []int64        `json:"units"`
+}
+
+type LoggedFoodUnit struct {
+	ID     int64  `json:"id"`
+	Name   string `json:"name"`
+	Plural string `json:"plural"`
+}
+
+type Nutritional struct {
+	Calories int64   `json:"calories"`
+	Carbs    float64 `json:"carbs"`
+	Fat      float64 `json:"fat"`
+	Fiber    float64 `json:"fiber"`
+	Protein  float64 `json:"protein"`
+	Sodium   float64 `json:"sodium"`
+	Water    float64 `json:"water,omitempty"`
+}

--- a/types/user_body.go
+++ b/types/user_body.go
@@ -13,8 +13,8 @@ type UserWeightGoal struct {
 type WeightGoal struct {
 	GoalType        string     `json:"goalType"`
 	StartDate       FitbitDate `json:"startDate"`
-	StartWeight     int64      `json:"startWeight"`
-	Weight          int64      `json:"weight"`
+	StartWeight     float64    `json:"startWeight"`
+	Weight          float64    `json:"weight"`
 	WeightThreshold float64    `json:"weightThreshold"`
 }
 


### PR DESCRIPTION
Fixes the following error:

```
json: cannot unmarshal number 100.5 into Go struct field WeightGoal.goal.startWeight of type int64
```